### PR TITLE
make course search query part of query params

### DIFF
--- a/online.codingblocks.com/pages/courses/index.vue
+++ b/online.codingblocks.com/pages/courses/index.vue
@@ -103,7 +103,7 @@ export default {
       // featuredTags: [], // using this server sides fails, see computed property
       offset: 0,
       limit: 9,
-      searchQuery: '',
+      searchQuery: this.$route.query.q != undefined ? this.$route.query.q : '',
       infiniteScrollDisabled: false
     }
   },
@@ -119,6 +119,10 @@ export default {
       return process.client ? this.$jsonApiStore.sync(this.featuredTagsPayload).sort((a,b)=>a.order - b.order) : []
     }
   },
+  mounted:function() {
+    if(this.searchQuery)
+      this.search.run(this.searchQuery);
+  },
   jsonld() {
     return jsonSchemaForAllCourses(this.courses)
   },
@@ -131,6 +135,7 @@ export default {
   tasks(t, { timeout }) {
     return {
       search: t(function *(query = '') {
+        this.$router.push({query: {q: query}})
         this.$nuxt.$loading.start()
         this.offset = 0 // reset pagination
         yield timeout(500)

--- a/online.codingblocks.com/pages/courses/index.vue
+++ b/online.codingblocks.com/pages/courses/index.vue
@@ -103,7 +103,7 @@ export default {
       // featuredTags: [], // using this server sides fails, see computed property
       offset: 0,
       limit: 9,
-      searchQuery: this.$route.query.q != undefined ? this.$route.query.q : '',
+      searchQuery: this.$route.query.q || '',
       infiniteScrollDisabled: false
     }
   },
@@ -119,7 +119,7 @@ export default {
       return process.client ? this.$jsonApiStore.sync(this.featuredTagsPayload).sort((a,b)=>a.order - b.order) : []
     }
   },
-  mounted:function() {
+  mounted() {
     if(this.searchQuery)
       this.search.run(this.searchQuery);
   },


### PR DESCRIPTION
closes #41 

- [x] Visiting `online.codingblocks.com/courses?q=android` should show android results
- [x] Searching for c++ in search box, the query params should also be updated along with the search results.